### PR TITLE
docs: Swapped "G" and "gg" commands in editors.md for correalignment

### DIFF
--- a/profile/essentials/editors/editors.md
+++ b/profile/essentials/editors/editors.md
@@ -83,7 +83,7 @@ The following short list of commands should allow you to do most of what you wil
 | `:w`      | write file (save)                                                                                                                              |
 | `:q`      | quit. Use `:q!` to exit without saving                                                                                                         |
 
-The great thing about learning these commands is that you will find that they work with a lot of the POSIX console programs. For example, with the file viewing utility `less` you can use `G` and `gg` to jump to the top and bottom of a file. Here is a [cheat sheet](https://vim.rtorr.com/) if you want to see all the commands.
+The great thing about learning these commands is that you will find that they work with a lot of the POSIX console programs. For example, with the file viewing utility `less` you can use `gg` and `G` to jump to the top and bottom of a file. Here is a [cheat sheet](https://vim.rtorr.com/) if you want to see all the commands.
 
 ### VI humor
 


### PR DESCRIPTION
The initial way the instruction was written implies that G takes you to the beginning of a file and gg take you the the end of it. It is actually vice versa.