### PR TITLE
docs: fix the wrong order of the sibling combinators to match their descriptions in the table.

### DIFF
--- a/profile/css/selectors/selectors.md
+++ b/profile/css/selectors/selectors.md
@@ -73,8 +73,8 @@ There are other types of combinators that you can use. These include the followi
 | ---------------- | -------------------------- | -------------- | ------------------------------------------ |
 | Descendant       | A list of descendants      | `body section` | Any section that is a descendant of a body |
 | Child            | A list of direct children  | `section > p`  | Any p that is a direct child of a section  |
-| General sibling  | A list of siblings         | `p ~ div`      | Any p that has a div sibling               |
-| Adjacent sibling | A list of adjacent sibling | `p + div`      | Any p that has an adjacent div sibling     |
+| General sibling  | A list of siblings         | `div ~ p`      | Any p that has a div sibling               |
+| Adjacent sibling | A list of adjacent sibling | `div + p`      | Any p that has an adjacent div sibling     |
 
 We can use the general sibling combinator to increase the whitespace padding on the left of paragraphs that are siblings of a level two heading.
 


### PR DESCRIPTION
There was a mixup in the order of the sibling combinator selectors: p ~ div selects divs with a p sibling, but the description says "Any p that has a div sibling". Same issue for both sibling examples in the table.